### PR TITLE
Redesign About modal with enhanced CRT terminal aesthetic

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -1,71 +1,109 @@
 <div class="modal fade" id="aboutModal" tabindex="-1" aria-labelledby="aboutModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-centered">
-        <div class="modal-content bg-dark border border-secondary text-light shadow-lg">
-            
-            <div class="modal-header border-secondary py-2 bg-black">
-                <h6 class="modal-title text-success fw-bold tracking-widest" id="aboutModalLabel">
-                    <span class="opacity-50">SYS //</span> SOCKET.KILL_MANIFEST
-                </h6>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
+        <div class="modal-content terminal-panel">
 
-            <div class="modal-body p-4" style="font-family: 'Exo 2', sans-serif; max-height: 70vh; overflow-y: auto;">
-                
-                <section class="mb-4">
-                    <h6 class="text-success fw-bold border-bottom border-secondary pb-1 uppercase small">Mission Profile</h6>
-                    <p class="small leading-relaxed">
-                        Socket.Kill is a high-performance front end inspired by the retro-futuristic CRT monitor presentation from the <em>Alien</em> franchise. Optimized for <strong>minimal overhead</strong>, a centralized image proxy and localized cache keep parsing performance <strong>under 100ms</strong>.
-                    </p>
-                </section>
-
-                <div class="row g-4 mb-4">
-                    <div class="col-md-4">
-                        <h6 class="text-success fw-bold x-small uppercase">Latency</h6>
-                        <p class="x-small text-secondary">Speeds governed by RedisQ API pulse rates.</p>
+            <!-- CRT Terminal Header -->
+            <div class="terminal-header">
+                <div class="d-flex align-items-center justify-content-between">
+                    <div>
+                        <div class="terminal-prompt">SOCKET.KILL v2.0.1</div>
+                        <div class="terminal-path">SYS://MANIFEST/ABOUT</div>
                     </div>
-                    <div class="col-md-4">
-                        <h6 class="text-success fw-bold x-small uppercase">Telemetry</h6>
-                        <p class="x-small text-secondary">Losses >1B ISK trigger <span class="text-danger">RED</span>. Extremes in <span class="text-warning">GOLD</span>.</p>
-                    </div>
-                    <div class="col-md-4">
-                        <h6 class="text-success fw-bold x-small uppercase">Privacy</h6>
-                        <p class="x-small text-secondary">No pilot data stored. Localized cache for speed only.</p>
-                    </div>
-                </div>
-
-                <section class="mb-4 bg-black p-3 border border-secondary rounded">
-                    <h6 class="text-success fw-bold small mb-3 uppercase">Comm Channels & Uplinks</h6>
-                    <div class="d-flex flex-wrap gap-3">
-                        <a href="https://ko-fi.com/X7X21RDFR0" target="_blank" class="btn btn-outline-primary btn-xs fw-bold x-small">
-                            💎 SUPPORT NODE (Ko-fi)
-                        </a>
-                        <a href="https://discord.gg/Sx5tFz6kcr" target="_blank" class="btn btn-outline-info btn-xs fw-bold x-small">
-                            📡 DISCORD BANTU
-                        </a>
-                        <a href="https://x.com/scottishdex" target="_blank" class="btn btn-outline-secondary btn-xs fw-bold x-small">
-                            🛰️ X_FEED
-                        </a>
-                        <a href="https://forms.gle/tjXJtzzmuqViFgTY7" target="_blank" class="btn btn-outline-success btn-xs fw-bold x-small">
-                            🛠️ Feedback & Feature Request
-                        </a>
-                    </div>
-                    <p class="mt-2 text-muted" style="font-size: 0.65rem;">*Donations facilitate the maintenance of the dedicated server droplet.</p>
-                </section>
-
-                <section class="mb-4 opacity-75">
-                    <h6 class="text-success fw-bold x-small mb-2 uppercase">💎 Credits</h6>
-                    <div class="x-small text-secondary">
-                        <strong>zKillboard:</strong> Squizz Caphinator // <strong>CCP Games:</strong> ESI & Image Server // <strong>Visuals:</strong> RixxJavix (Backgrounds)
-                    </div>
-                </section>
-
-                <div class="mt-4 pt-2 border-top border-secondary opacity-50" style="font-size: 0.65rem;">
-                    <p class="mb-0 italic">EVE Online and the EVE logo are registered trademarks of CCP hf. All artwork and recognizable features are intellectual property of CCP hf.</p>
+                    <button type="button" class="terminal-close" data-bs-dismiss="modal" aria-label="Close">
+                        <span>[ X ]</span>
+                    </button>
                 </div>
             </div>
 
-            <div class="modal-footer border-top-0 bg-black">
-                <button type="button" class="btn btn-outline-success btn-sm w-100 fw-bold" data-bs-dismiss="modal">RE-ENGAGE FEED</button>
+            <!-- Terminal Body with Scanlines -->
+            <div class="terminal-body">
+
+                <!-- Mission Profile -->
+                <section class="terminal-section">
+                    <div class="terminal-section-header">
+                        <span class="terminal-bracket">&gt;&gt;</span> MISSION_PROFILE
+                    </div>
+                    <div class="terminal-text">
+                        Socket.Kill is a high-performance front end inspired by the retro-futuristic CRT monitor presentation from the <span class="text-warning">Alien</span> franchise. Optimized for <span class="terminal-highlight">minimal overhead</span>, a centralized image proxy and localized cache keep parsing performance <span class="terminal-highlight">&lt;100ms</span>.
+                    </div>
+                </section>
+
+                <!-- System Specs Grid -->
+                <section class="terminal-section">
+                    <div class="terminal-section-header">
+                        <span class="terminal-bracket">&gt;&gt;</span> SYSTEM_SPECIFICATIONS
+                    </div>
+                    <div class="terminal-grid">
+                        <div class="terminal-grid-item">
+                            <div class="terminal-label">[LATENCY]</div>
+                            <div class="terminal-value">Governed by RedisQ API pulse rates</div>
+                        </div>
+                        <div class="terminal-grid-item">
+                            <div class="terminal-label">[TELEMETRY]</div>
+                            <div class="terminal-value">Losses &gt;1B ISK trigger <span class="text-danger">RED</span> | Extremes <span class="text-warning">GOLD</span></div>
+                        </div>
+                        <div class="terminal-grid-item">
+                            <div class="terminal-label">[PRIVACY]</div>
+                            <div class="terminal-value">No pilot data stored. Local cache only.</div>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Communication Channels -->
+                <section class="terminal-section terminal-links-section">
+                    <div class="terminal-section-header">
+                        <span class="terminal-bracket">&gt;&gt;</span> COMM_CHANNELS
+                    </div>
+                    <div class="terminal-links">
+                        <a href="https://ko-fi.com/X7X21RDFR0" target="_blank" class="terminal-link">
+                            <span class="terminal-link-icon">💎</span>
+                            <span class="terminal-link-text">SUPPORT_NODE</span>
+                            <span class="terminal-link-arrow">→</span>
+                        </a>
+                        <a href="https://discord.gg/Sx5tFz6kcr" target="_blank" class="terminal-link">
+                            <span class="terminal-link-icon">📡</span>
+                            <span class="terminal-link-text">DISCORD_BANTU</span>
+                            <span class="terminal-link-arrow">→</span>
+                        </a>
+                        <a href="https://x.com/scottishdex" target="_blank" class="terminal-link">
+                            <span class="terminal-link-icon">🛰️</span>
+                            <span class="terminal-link-text">X_FEED</span>
+                            <span class="terminal-link-arrow">→</span>
+                        </a>
+                        <a href="https://forms.gle/tjXJtzzmuqViFgTY7" target="_blank" class="terminal-link">
+                            <span class="terminal-link-icon">🛠️</span>
+                            <span class="terminal-link-text">FEEDBACK_FORM</span>
+                            <span class="terminal-link-arrow">→</span>
+                        </a>
+                    </div>
+                    <div class="terminal-note">
+                        *Donations facilitate dedicated server droplet maintenance
+                    </div>
+                </section>
+
+                <!-- Credits -->
+                <section class="terminal-section">
+                    <div class="terminal-section-header">
+                        <span class="terminal-bracket">&gt;&gt;</span> CREDITS
+                    </div>
+                    <div class="terminal-credits">
+                        <div><span class="terminal-credit-key">zKillboard:</span> Squizz Caphinator</div>
+                        <div><span class="terminal-credit-key">CCP Games:</span> ESI & Image Server</div>
+                        <div><span class="terminal-credit-key">Visuals:</span> RixxJavix (Backgrounds)</div>
+                    </div>
+                </section>
+
+                <!-- Legal -->
+                <div class="terminal-legal">
+                    EVE Online and the EVE logo are registered trademarks of CCP hf. All artwork and recognizable features are intellectual property of CCP hf.
+                </div>
+            </div>
+
+            <!-- Footer Command -->
+            <div class="terminal-footer">
+                <button type="button" class="terminal-button" data-bs-dismiss="modal">
+                    <span class="terminal-button-prompt">$</span> CLOSE_MANIFEST
+                </button>
             </div>
         </div>
     </div>

--- a/public/style.css
+++ b/public/style.css
@@ -397,3 +397,338 @@ body {
     /* Boot sequence on load, then continuous subtle flicker */
     animation: crt-boot 1.5s ease-out, cathode-flicker 0.15s infinite 1.5s;
 }
+
+/* ========================================
+   TERMINAL MODAL - Alien CRT Aesthetic
+   ======================================== */
+
+.terminal-panel {
+    background: #000000;
+    border: 2px solid #3fb950;
+    box-shadow:
+        0 0 20px rgba(63, 185, 80, 0.3),
+        inset 0 0 100px rgba(63, 185, 80, 0.03);
+    font-family: 'Share Tech Mono', 'Courier New', monospace;
+    color: #3fb950;
+    position: relative;
+    overflow: hidden;
+}
+
+/* Scanline overlay for terminal */
+.terminal-panel::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+        rgba(63, 185, 80, 0) 50%,
+        rgba(0, 0, 0, 0.1) 50%
+    );
+    background-size: 100% 4px;
+    pointer-events: none;
+    z-index: 1;
+}
+
+/* Phosphor glow overlay */
+.terminal-panel::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: radial-gradient(
+        ellipse at center,
+        transparent 0%,
+        transparent 70%,
+        rgba(0, 0, 0, 0.3) 100%
+    );
+    pointer-events: none;
+    z-index: 1;
+}
+
+/* Terminal Header */
+.terminal-header {
+    background: rgba(63, 185, 80, 0.08);
+    border-bottom: 1px solid #3fb950;
+    padding: 12px 20px;
+    position: relative;
+    z-index: 2;
+}
+
+.terminal-prompt {
+    font-size: 0.9rem;
+    font-weight: bold;
+    color: #3fb950;
+    text-shadow: 0 0 5px rgba(63, 185, 80, 0.5);
+    letter-spacing: 1px;
+}
+
+.terminal-path {
+    font-size: 0.7rem;
+    color: #58a6ff;
+    opacity: 0.7;
+    margin-top: 2px;
+}
+
+.terminal-close {
+    background: transparent;
+    border: 1px solid #3fb950;
+    color: #3fb950;
+    padding: 4px 12px;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.terminal-close:hover {
+    background: #3fb950;
+    color: #000000;
+    box-shadow: 0 0 10px rgba(63, 185, 80, 0.5);
+}
+
+/* Terminal Body */
+.terminal-body {
+    padding: 20px;
+    max-height: 70vh;
+    overflow-y: auto;
+    position: relative;
+    z-index: 2;
+    font-size: 0.85rem;
+    line-height: 1.6;
+}
+
+/* Custom Scrollbar */
+.terminal-body::-webkit-scrollbar {
+    width: 8px;
+}
+
+.terminal-body::-webkit-scrollbar-track {
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.terminal-body::-webkit-scrollbar-thumb {
+    background: #3fb950;
+    border-radius: 4px;
+}
+
+.terminal-body::-webkit-scrollbar-thumb:hover {
+    background: #58a6ff;
+}
+
+/* Section Styling */
+.terminal-section {
+    margin-bottom: 25px;
+}
+
+.terminal-section-header {
+    color: #58a6ff;
+    font-size: 0.9rem;
+    font-weight: bold;
+    margin-bottom: 10px;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    text-shadow: 0 0 3px rgba(88, 166, 255, 0.3);
+}
+
+.terminal-bracket {
+    color: #3fb950;
+    margin-right: 5px;
+}
+
+.terminal-text {
+    color: #c9d1d9;
+    padding-left: 20px;
+    font-size: 0.85rem;
+}
+
+.terminal-highlight {
+    color: #3fb950;
+    font-weight: bold;
+    text-shadow: 0 0 3px rgba(63, 185, 80, 0.3);
+}
+
+/* Grid Layout */
+.terminal-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 15px;
+    padding-left: 20px;
+}
+
+.terminal-grid-item {
+    border-left: 2px solid #3fb950;
+    padding-left: 15px;
+}
+
+.terminal-label {
+    color: #58a6ff;
+    font-size: 0.75rem;
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
+.terminal-value {
+    color: #c9d1d9;
+    font-size: 0.8rem;
+}
+
+/* Communication Links */
+.terminal-links-section {
+    background: rgba(63, 185, 80, 0.03);
+    border: 1px solid rgba(63, 185, 80, 0.2);
+    padding: 15px;
+    border-radius: 4px;
+}
+
+.terminal-links {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-left: 20px;
+}
+
+.terminal-link {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 15px;
+    background: rgba(0, 0, 0, 0.5);
+    border: 1px solid #3fb950;
+    color: #3fb950;
+    text-decoration: none;
+    transition: all 0.2s;
+    font-size: 0.85rem;
+    position: relative;
+}
+
+.terminal-link::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 3px;
+    height: 100%;
+    background: #3fb950;
+    transform: scaleY(0);
+    transition: transform 0.2s;
+}
+
+.terminal-link:hover {
+    background: rgba(63, 185, 80, 0.1);
+    color: #ffffff;
+    box-shadow: 0 0 15px rgba(63, 185, 80, 0.3);
+    transform: translateX(5px);
+}
+
+.terminal-link:hover::before {
+    transform: scaleY(1);
+}
+
+.terminal-link-icon {
+    font-size: 1rem;
+}
+
+.terminal-link-text {
+    flex: 1;
+    letter-spacing: 1px;
+}
+
+.terminal-link-arrow {
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
+.terminal-link:hover .terminal-link-arrow {
+    opacity: 1;
+}
+
+.terminal-note {
+    color: #7d8590;
+    font-size: 0.7rem;
+    margin-top: 15px;
+    padding-left: 20px;
+    font-style: italic;
+}
+
+/* Credits Section */
+.terminal-credits {
+    padding-left: 20px;
+    font-size: 0.8rem;
+    color: #c9d1d9;
+    line-height: 1.8;
+}
+
+.terminal-credit-key {
+    color: #58a6ff;
+    font-weight: bold;
+}
+
+/* Legal Text */
+.terminal-legal {
+    margin-top: 20px;
+    padding-top: 15px;
+    border-top: 1px solid rgba(63, 185, 80, 0.2);
+    font-size: 0.65rem;
+    color: #7d8590;
+    opacity: 0.6;
+    text-align: center;
+    font-style: italic;
+}
+
+/* Terminal Footer */
+.terminal-footer {
+    background: rgba(0, 0, 0, 0.8);
+    border-top: 1px solid #3fb950;
+    padding: 15px 20px;
+    position: relative;
+    z-index: 2;
+}
+
+.terminal-button {
+    width: 100%;
+    background: transparent;
+    border: 2px solid #3fb950;
+    color: #3fb950;
+    padding: 12px 20px;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 0.9rem;
+    font-weight: bold;
+    cursor: pointer;
+    transition: all 0.2s;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+.terminal-button:hover {
+    background: #3fb950;
+    color: #000000;
+    box-shadow: 0 0 20px rgba(63, 185, 80, 0.5);
+    text-shadow: none;
+}
+
+.terminal-button-prompt {
+    color: #58a6ff;
+    margin-right: 8px;
+}
+
+/* Modal Backdrop Enhancement */
+.modal-backdrop.show {
+    opacity: 0.9;
+    backdrop-filter: blur(3px);
+}
+
+/* Responsive Adjustments */
+@media (max-width: 768px) {
+    .terminal-body {
+        font-size: 0.8rem;
+    }
+
+    .terminal-link {
+        font-size: 0.75rem;
+        padding: 8px 12px;
+    }
+}


### PR DESCRIPTION
Complete overhaul of the about modal to match Alien-inspired CRT theme:

HTML Changes (about.html):
- Restructured layout with terminal-style header, body, footer
- Added system path display (SYS://MANIFEST/ABOUT)
- Converted sections to command-line style with >> brackets
- Link buttons now styled as terminal commands with hover arrows
- Maintained all original content and links

CSS Changes (style.css):
- Added comprehensive terminal styling with phosphor green (#3fb950)
- Scanline overlay for authentic CRT effect
- Radial vignette for curved screen simulation
- Glowing borders and text shadows for phosphor effect
- Animated link hovers with sliding accent bar
- Custom scrollbar matching terminal theme
- Responsive design for mobile devices
- All links and support options retained with improved UX

The modal now feels like an authentic retro terminal interface while keeping all functionality and information intact.