### PR TITLE
Selected bug fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -278,7 +278,24 @@ async function startPoller() {
 }
 
 
-// --- Boot -
+// --- Graceful Shutdown ---
+
+async function shutdown(signal) {
+  console.log(`[SHUTDOWN] ${signal} received — flushing state before exit...`);
+  try {
+    await hashCache.flush();
+    statsManager.save();
+    console.log("[SHUTDOWN] Flush complete. Exiting.");
+  } catch (err) {
+    console.error(`[SHUTDOWN] Flush error: ${err.message}`);
+  }
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT",  () => shutdown("SIGINT"));
+
+// --- Boot ---
 (async () => {
   console.log("Initializing Socket.Kill...");
   // await esi.loadSystemCache("./data/systems.json");

--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -55,18 +55,12 @@ class utils {
     }
   }
 
-  static async getBackPhoto() {
-    try {
-      const url = process.env.BACKGROUND_API_URL;
-      return {
-        url: url,
-        name: "EVE Online Nebula",
-        media_type: "image",
-      };
-    } catch (err) {
-      console.error("Background Pic Retrieval Issue", err.message);
-      return null;
-    }
+  static getBackPhoto() {
+    return {
+      url: process.env.BACKGROUND_API_URL,
+      name: "EVE Online Nebula",
+      media_type: "image",
+    };
   }
 
   static formatDuration(ms) {

--- a/src/core/processor_v2.js
+++ b/src/core/processor_v2.js
@@ -42,7 +42,7 @@ module.exports = (esi, io, statsManager) => {
             console.log(`[PERF] Kill ${killID} | Latency: ${durationMs.toFixed(3)}ms`);
             io.emit("gatekeeper-stats", {
                 totalScanned: statsManager.getTotal(),
-                totalisk: statsManager.totalIsk
+                totalIsk: statsManager.totalIsk
             });
             io.emit("raw-kill", {
                 id: killID,

--- a/src/network/esi.js
+++ b/src/network/esi.js
@@ -152,7 +152,6 @@ class ESIClient {
     // }
 
     async loadSystemCache() {
-        console.log('[BOOT] systems loaded on instance', this._instanceId = Math.random());
         try {
             const kv = require ('./kvClient');
             this.staticSystemData = await kv.get('systems:all');
@@ -191,7 +190,7 @@ class ESIClient {
     getSystemDetails(id) {
         const result = this.staticSystemData[id] || null;
         if (!result) {
-            console.log('[SYS MISS]', id, 'instance', this._instanceId, 'data size', Object.keys(this.staticSystemData || {}).length);
+            console.warn(`[SYS MISS] Unknown system ID: ${id}`);
         }
         return result;
     }

--- a/src/services/statsManager.js
+++ b/src/services/statsManager.js
@@ -45,7 +45,7 @@ class StatsManager {
 async recoverFromR2() {
     const stats = await r2.get('stats.json');
     if (stats) {
-        this.totalScanned = stats.totalKills || this.totalScanned;
+        this.totalScanned = stats.totalKills ?? this.totalScanned;
         console.log(`[STATS] Loaded ${this.totalScanned} kills from R2`);
     } else {
         console.log(`[STATS] R2 unavailable, using disk: ${this.totalScanned} kills`);
@@ -53,7 +53,7 @@ async recoverFromR2() {
 
     const financials = await r2.get('financials.json');
     if (financials) {
-        this.totalIsk = financials.totalIsk || this.totalIsk;
+        this.totalIsk = financials.totalIsk ?? this.totalIsk;
         console.log(`[STATS] Loaded ISK from R2`);
     } else {
         console.log(`[STATS] R2 unavailable, using disk ISK`);


### PR DESCRIPTION
## Summary

Five targeted bug fixes identified during codebase analysis. No changes to kill ingestion logic, webhook routing, or stream behaviour.

## Fixes

- **Graceful shutdown** (`index.js`) — added `SIGTERM`/`SIGINT` handlers that flush `hashCache` and `statsManager` before exit; previously an unclean shutdown (Docker stop, process signal) discarded all in-memory state silently with no flush

- **`gatekeeper-stats` field typo** (`processor_v2.js`) — `totalisk` → `totalIsk`; this emitter was sending a different field name than every other emitter, so clients received inconsistent data depending on which code path triggered the event

- **`recoverFromR2` falsy guard** (`statsManager.js`) — replaced `||` with `??` on both `totalKills` and `totalIsk`; a legitimate stored value of `0` was being discarded as falsy and falling back to `undefined`

- **`getBackPhoto` dead try/catch** (`helpers.js`) — removed unreachable `try/catch` and `async`; the function body is pure synchronous env-var access that cannot throw

- **ESI debug artefacts** (`esi.js`) — removed `this._instanceId = Math.random()` side-effectful assignment inside a log call in `loadSystemCache`; cleaned up the `[SYS MISS]` log that referenced it and upgraded it to `console.warn`

https://claude.ai/code/session_011MBwAyHkAgCxoYXeDW1mM3

---
_Generated by [Claude Code](https://claude.ai/code/session_011MBwAyHkAgCxoYXeDW1mM3)_